### PR TITLE
Fix for migrate process picking up env through dotenv

### DIFF
--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -3,8 +3,9 @@ var r,
   path = require('path'),
   chalk = require('chalk'),
   nconf = require('nconf'),
-  dotenv = require('dotenv');
   _ = require('lodash');
+
+require("dotenv").load({ path: "./.env-defaults" });
 
 var MIGRATION_TABLE_NAME = '_migrations';
 


### PR DESCRIPTION
The dotenv module was called but not being used.
This fix calls its load function and specifies .env-defaults as well